### PR TITLE
Decrypt as a service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 vault-plugin-secrets-ejson
+vault/plugins

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,11 @@ endif
 all: fmt test build
 
 build:
-	GOOS=$(OS) GOARCH="$(GOARCH)" go build -mod vendor -o vault-plugin-secrets-ejson cmd/vault-plugin-secrets-ejson/main.go
+	GOOS=$(OS) GOARCH="$(GOARCH)" go build -mod vendor -o vault/plugins/secrets-ejson cmd/vault-plugin-secrets-ejson/main.go
 
 clean:
 	rm -f ./vault-plugin-secrets-ejson
+	rm -rf ./vault/plugins/
 
 deps:
 	go mod tidy
@@ -29,5 +30,12 @@ fmt:
 test:
 	go vet $$(go list ./...)
 	GOOS=$(OS) GOARCH="$(GOARCH)" go test -v -cover $$(go list ./...)
+
+server:
+	vault server -dev -dev-root-token-id=root -dev-plugin-dir=./vault/plugins
+
+loadPlugin:
+	export VAULT_ADDR='http://127.0.0.1:8200'
+	vault secrets enable -path=ejson secrets-ejson
 
 .PHONY: all build clean deps fmt test

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## Summary
 
-A secret plugin for use with [Hashicorp Vault](https://www.github.com/hashicorp/vault). This plugin provides the ability to submit [EJSON](https://github.com/Shopify/ejson) to Vault wherein it will be decrypted and stored.
+A secret plugin for use with [Hashicorp Vault](https://www.github.com/hashicorp/vault). This plugin provides the ability to submit and manipulate [EJSON](https://github.com/Shopify/ejson) to Vault wherein it can be decrypted and/or stored.
 
-Any key values prefixed with an underscore will be stored with the underscore removed at the decrypted path (see below for an example). This is done intentionally to keep data access sane.
+Note: For storage operations, any key values prefixed with an underscore will be stored with the underscore removed at the decrypted path (see below for an example). This is done intentionally to keep data access sane.
 
 ## Usage
 
@@ -31,7 +31,9 @@ Success! Enabled the vault-plugin-secrets-ejson plugin at: ejson/
 ### Installing for production use
 Please consult official Vault documentation on how to checksum, load and enable plugins.
 
-### Demo
+## Demo
+
+### Storing public-private-keypairs (/keys/.*)
 
 ```bash
 # Storing the public/private key for decryption
@@ -40,8 +42,10 @@ $ vault write ejson/keys/15838c2f3260185ad2a8e1298bd507479ff2470b9e9c1fd89e0fdfe
 Key        Value
 ---        -----
 private    37124bcf00c2d9fd87ddd596162d99c004460fd47130f2d653e45f85a0681cf0
+```
 
-
+### Storing ejson documents (/.*)
+```bash
 $ cat itsasecret.ejson
 {
   "_public_key": "15838c2f3260185ad2a8e1298bd507479ff2470b9e9c1fd89e0fdfefe2959f56",
@@ -67,6 +71,31 @@ Key      Value
 ---      -----
 ejson    map[anumber:1 asecret:ohai bsecret:orly]
 ```
+
+### Decrypting an ejson document on the fly with EaaS (/decrypt)
+```bash
+$ vault write -format=json ejson/decrypt @itsasecret.ejson
+{
+  "request_id": "3df23dd2-7c41-3c3f-b5e4-d5300906bd78",
+  "lease_id": "",
+  "lease_duration": 0,
+  "renewable": false,
+  "data": {
+    "_bsecret": "orly",
+    "_public_key": "15838c2f3260185ad2a8e1298bd507479ff2470b9e9c1fd89e0fdfefe2959f56",
+    "anumber": 1,
+    "asecret": "to everyone",
+    "database": {
+      "_username": "admin",
+      "password": "sicher"
+    }
+  },
+  "warnings": null
+}
+```
+
+
+### Terraform integration
 
 This plugin can also be used with Terraform's `vault_generic_secret` resource to safely store version controlled secrets inside of Vault.
 

--- a/README.md
+++ b/README.md
@@ -10,34 +10,26 @@ Any key values prefixed with an underscore will be stored with the underscore re
 
 ## Usage
 
-### Installing
+### Installing for development use
 
 ```bash
-# Generate a Vault config detailing where the plugin directory is located
-$ tee vault-config.hcl <<EOF
-plugin_directory = "/vault/plugins"
-EOF
+# Build the binary
+$ make build
 
 # Run Vault
 # NOTE: Do not run -dev in production
-$ vault server -dev -dev-root-token-id="root" -config=vault-config.hcl
+$ vault server -dev -dev-root-token-id=root -dev-plugin-dir=./vault/plugins
 
 # Export VAULT_ADDR for future `vault` commands
 $ export VAULT_ADDR='http://127.0.0.1:8200'
 
-# Build the binary
-$ make build
-
-# Generate checksum, and tell Vault about the plugin
-$ SHASUM=$(shasum -a 256 "/vault/plugins/vault-plugin-secrets-ejson" | cut -d " " -f1)
-$ vault write sys/plugins/catalog/secret/vault-plugin-secrets-ejson \
-  sha_256="$SHASUM" \
-  command="vault-plugin-secrets-ejson"
-
 # Enable the plugin at a specific path (in this case ejson/)
-$ vault secrets enable -path=ejson -plugin-name=vault-plugin-secrets-ejson plugin
+$ vault secrets enable -path=ejson secrets-ejson
 Success! Enabled the vault-plugin-secrets-ejson plugin at: ejson/
 ```
+
+### Installing for production use
+Please consult official Vault documentation on how to checksum, load and enable plugins.
 
 ### Demo
 

--- a/backend.go
+++ b/backend.go
@@ -35,6 +35,7 @@ func Backend() *backend {
 	b.Backend = &framework.Backend{
 		Help: "",
 		Paths: framework.PathAppend(
+			ejsonDecryptPaths(&b),
 			ejsonKeysPaths(&b),
 			ejsonPaths(&b),
 		),

--- a/helper.go
+++ b/helper.go
@@ -1,0 +1,51 @@
+package secretsejson
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Shopify/ejson"
+	ej "github.com/Shopify/ejson/json"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func DecryptEjsonDocument(ctx context.Context, req *logical.Request, encData []byte) (map[string]interface{}, error) {
+	var out bytes.Buffer
+	var err error
+
+	pubKey, err := ej.ExtractPublicKey(encData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract public key: %s", err)
+	}
+
+	// Find the matching public key in keys/
+	keyPair, err := req.Storage.Get(ctx, fmt.Sprintf("keys/%x", pubKey))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find public key in keys/: %s", err)
+	}
+
+	if err := ejson.Decrypt(bytes.NewBuffer(encData), &out, "", string(keyPair.Value)); err != nil {
+		return nil, fmt.Errorf("failed to decrypt ejson: %s", err)
+	}
+	decData := map[string]interface{}{}
+	if err := json.Unmarshal(out.Bytes(), &decData); err != nil {
+		return nil, err
+	}
+
+	return decData, nil
+}
+
+func MarshalInput(inputData interface{}) ([]byte, error) {
+	switch value := inputData.(type) {
+	case map[string]interface{}:
+		encData, err := json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+		return encData, nil
+	default:
+		return nil, fmt.Errorf("data provided was in an unexpected format")
+	}
+}

--- a/path_ejson_decrypt.go
+++ b/path_ejson_decrypt.go
@@ -1,0 +1,51 @@
+package secretsejson
+
+import (
+	"context"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func ejsonDecryptPaths(b *backend) []*framework.Path {
+	return []*framework.Path{
+		&framework.Path{
+			Pattern: "decrypt",
+			Fields: map[string]*framework.FieldSchema{
+				"document": &framework.FieldSchema{
+					Type:        framework.TypeString,
+					Description: "ejson document",
+				},
+			},
+			Callbacks: map[logical.Operation]framework.OperationFunc{
+				logical.CreateOperation: b.decrypt,
+				logical.UpdateOperation: b.decrypt,
+			},
+		},
+	}
+}
+
+func (b *backend) decrypt(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	inputData, ok := data.GetOk("ejson")
+	if !ok {
+		if len(data.Raw) == 0 {
+			return logical.ErrorResponse("no data provided"), logical.ErrInvalidRequest
+		}
+		inputData = data.Raw
+	}
+
+	encData, err := MarshalInput(inputData)
+	if err != nil {
+		return nil, errwrap.Wrapf("failed to marshall json: {{err}}", err)
+	}
+
+	decData, err := DecryptEjsonDocument(ctx, req, encData)
+	if err != nil {
+		return nil, errwrap.Wrapf("failed to decrypt ejson: {{err}}", err)
+	}
+
+	return &logical.Response{
+		Data: decData,
+	}, nil
+}

--- a/path_ejson_decrypt_test.go
+++ b/path_ejson_decrypt_test.go
@@ -1,0 +1,42 @@
+package secretsejson
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func TestEJSON_Decrypt(t *testing.T) {
+	b, storage := getTestBackend(t)
+
+	EJSON_Keys_Setup(t, b, storage)
+
+	dataInput := map[string]interface{}{
+		"_public_key": "15838c2f3260185ad2a8e1298bd507479ff2470b9e9c1fd89e0fdfefe2959f56",
+		"asecret":     "EJ[1:sdseJpJ3BpP9PO5Qs8IB4urmmYil46edSTek8SjgVGA=:zl7mkBzL4g2d0PE3hPucmfbDjf3aDK7K:iryi3H7wRGWvUI8kjfWLtP3sFiw=]",
+		"_bsecret":    "intentionally_left_unencrypted",
+		"anumber":     1,
+	}
+
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "decrypt",
+		Storage:   storage,
+		Data:      dataInput,
+	}
+
+	resp, err := b.HandleRequest(context.Background(), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+	dataDec := dataInput
+	dataDec["asecret"] = "ohai"
+	dataDec["anumber"] = float64(1) // deep equal is a little too picky on numbers here
+
+	if !reflect.DeepEqual(resp.Data, dataDec) {
+		t.Fatalf("Bad decryption response: \nGot: %#v\nWant: %#v", resp.Data, dataDec)
+	}
+}


### PR DESCRIPTION
## Decryption as a service
This change introduces a [transit engine-like `/decrypt` operation](https://learn.hashicorp.com/tutorials/vault/eaas-transit#decrypt-ciphertext) for ejson documents. It can be used to retrieve a plain text version of a given document on the fly, if its corresponding private key is stored in this plugins `/keys/.*` feature.

The decryption functionality was taken from the existing ejson storage feature, moved into a helper function.

### Example
```bash
$ cat /tmp/test.ejson
{
  "_public_key": "3f809a054114cb2565b465628c012999a46db9500ef11c53c677d72f87fc423a",
  "asecret": "EJ[1:VvFAan4fsMWGrepS0nAwkb1YkQRo6G5dUnVvLGeegDY=:VJ2+PXTQR9uIOjWQtTc5ykWe/LCRBjvJ:aWDIXEQZJIF1QcwiGeZtNE2XPXCxBDmJQBQb]",
  "_bsecret": "orly",
  "anumber": 1,
  "database": {
    "_username": "admin",
    "password": "EJ[1:T1QHzJ6e9rwwslkKxFTXcDhnn/7qogTbw0uo7o7bQG0=:usSbJugttuRf7ys7oxjIUYL01dBzqUFx:MpnEaualgIHbCVOZwuVa5HY7pf02uw==]"
  }
}
$ vault write -format=json ejson/decrypt @/tmp/test.ejson | jq .data
{
  "_bsecret": "orly",
  "_public_key": "3f809a054114cb2565b465628c012999a46db9500ef11c53c677d72f87fc423a",
  "anumber": 1,
  "asecret": "to everyone",
  "database": {
    "_username": "admin",
    "password": "sicher"
  }
}
```

## Housekeeping
While developing I ran into some inconsistencies in documentation, notably between this projects readme and the suggested way of doing things in Vaults help pages. It seems since this plugins initial creating Vault has improved how to load plugins in development mode, no longer requiring shasuming and config file changes. This PR updates the readme accordingly as well as introduces two new helper make tasks.

## Known bugs
Trying to decrypt a document for which the private key does not exist in vault, the current logic does not sufficiently check the keys existence and results in the plugin crashing, rather than handling the error and returning a meaningful message.
**This behaviour predates this change and is observable on the current version for the `ejson/.*` endpoint as well.**
Edit: this has been fixed further down the line with https://github.com/Shopify/vault-plugin-secrets-ejson/pull/6/commits/a2adf3c3caf0eefea61f6c62f964063a8397c546#diff-23c2816372c1361306d02f4c71938a8b2b4474cb4b26d711524167ae1175bf87R40

## Caution
Please note that a policy that gives access to this path allows to decrypt ALL ejson documents, even if there are other policies that would restrict an entities access to other keys. Thinking about moving this to `keys/.{64}/decrypt` with an upcoming PR.
