### PR TITLE
Analyse as a service

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -35,6 +35,7 @@ func Backend() *backend {
 	b.Backend = &framework.Backend{
 		Help: "",
 		Paths: framework.PathAppend(
+			ejsonAnalysePaths(&b),
 			ejsonIdentityPath(&b),
 			ejsonDecryptPaths(&b),
 			ejsonKeysPaths(&b),

--- a/helper.go
+++ b/helper.go
@@ -37,8 +37,11 @@ func DecryptEjson(ctx context.Context, encData []byte, storage logical.Storage) 
 
 	// Find the matching public key in keys/
 	keyPair, err := storage.Get(ctx, fmt.Sprintf("keys/%x", pubKey))
-	if err != nil || keyPair == nil {
+	if err != nil {
 		return nil, fmt.Errorf("failed to find public key in keys/: %s", err)
+	}
+	if keyPair == nil {
+		return nil, fmt.Errorf("failed to find key in keys/%x", pubKey)
 	}
 
 	if err := ejson.Decrypt(bytes.NewBuffer(encData), &out, "", string(keyPair.Value)); err != nil {

--- a/helper.go
+++ b/helper.go
@@ -13,6 +13,20 @@ import (
 )
 
 func DecryptEjsonDocument(ctx context.Context, req *logical.Request, encData []byte) (map[string]interface{}, error) {
+
+	decBytes, err := DecryptEjson(ctx, encData, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	decData := map[string]interface{}{}
+	if err := json.Unmarshal(decBytes, &decData); err != nil {
+		return nil, err
+	}
+
+	return decData, nil
+}
+
+func DecryptEjson(ctx context.Context, encData []byte, storage logical.Storage) ([]byte, error) {
 	var out bytes.Buffer
 	var err error
 
@@ -22,33 +36,32 @@ func DecryptEjsonDocument(ctx context.Context, req *logical.Request, encData []b
 	}
 
 	// Find the matching public key in keys/
-	keyPair, err := req.Storage.Get(ctx, fmt.Sprintf("keys/%x", pubKey))
-	if err != nil {
+	keyPair, err := storage.Get(ctx, fmt.Sprintf("keys/%x", pubKey))
+	if err != nil || keyPair == nil {
 		return nil, fmt.Errorf("failed to find public key in keys/: %s", err)
 	}
 
 	if err := ejson.Decrypt(bytes.NewBuffer(encData), &out, "", string(keyPair.Value)); err != nil {
 		return nil, fmt.Errorf("failed to decrypt ejson: %s", err)
 	}
-	decData := map[string]interface{}{}
-	if err := json.Unmarshal(out.Bytes(), &decData); err != nil {
-		return nil, err
-	}
-
-	return decData, nil
+	return out.Bytes(), nil
 }
 
 func MarshalInput(inputData interface{}) ([]byte, error) {
 	switch value := inputData.(type) {
 	case map[string]interface{}:
-		encData, err := json.Marshal(value)
-		if err != nil {
-			return nil, err
-		}
-		return encData, nil
+		return MarshalForEjson(value)
 	default:
 		return nil, fmt.Errorf("data provided was in an unexpected format")
 	}
+}
+
+func MarshalForEjson(input map[string]interface{}) ([]byte, error) {
+	bytes, err := json.Marshal(input)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
 }
 
 func HashPlaintext(plaintext []byte, salt []byte) ([]byte, error) {

--- a/path_ejson_analyse.go
+++ b/path_ejson_analyse.go
@@ -1,0 +1,167 @@
+package secretsejson
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	ej "github.com/Shopify/ejson/json"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func typeRegexes() map[string]string {
+
+	// Adapted from https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
+	// Regexp list is GNU General Public License v3.0, see https://github.com/dxa4481/truffleHogRegexes/blob/master/LICENSE
+	truffehogRegexesJson := `{
+		"Slack Token": "(xox[pboa]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})",
+		"RSA private key": "-----BEGIN RSA PRIVATE KEY-----",
+		"SSH (DSA) private key": "-----BEGIN DSA PRIVATE KEY-----",
+		"SSH (EC) private key": "-----BEGIN EC PRIVATE KEY-----",
+		"PGP private key block": "-----BEGIN PGP PRIVATE KEY BLOCK-----",
+		"AWS API Key": "((?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16})",
+		"Amazon MWS Auth Token": "amzn\\.mws\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+		"AWS API Key": "AKIA[0-9A-Z]{16}",
+		"AWS AppSync GraphQL Key": "da2-[a-z0-9]{26}",
+		"Facebook Access Token": "EAACEdEose0cBA[0-9A-Za-z]+",
+		"Facebook OAuth": "[fF][aA][cC][eE][bB][oO][oO][kK].*['|\"][0-9a-f]{32}['|\"]",
+		"GitHub": "[gG][iI][tT][hH][uU][bB].*['|\"][0-9a-zA-Z]{35,40}['|\"]",
+		"GitHub PAT": "ghp_[0-9a-zA-Z]{35,40}",
+		"Generic API Key": "[aA][pP][iI]_?[kK][eE][yY].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
+		"Generic Secret": "[sS][eE][cC][rR][eE][tT].*['|\"][0-9a-zA-Z]{32,45}['|\"]",
+		"Google API Key": "AIza[0-9A-Za-z\\-_]{35}",
+		"Google Cloud Platform API Key": "AIza[0-9A-Za-z\\-_]{35}",
+		"Google Cloud Platform OAuth": "[0-9]+-[0-9A-Za-z_]{32}\\.apps\\.googleusercontent\\.com",
+		"Google Drive API Key": "AIza[0-9A-Za-z\\-_]{35}",
+		"Google Drive OAuth": "[0-9]+-[0-9A-Za-z_]{32}\\.apps\\.googleusercontent\\.com",
+		"Google (GCP) Service-account": "\"type\": \"service_account\"",
+		"Google Gmail API Key": "AIza[0-9A-Za-z\\-_]{35}",
+		"Google Gmail OAuth": "[0-9]+-[0-9A-Za-z_]{32}\\.apps\\.googleusercontent\\.com",
+		"Google OAuth Access Token": "ya29\\.[0-9A-Za-z\\-_]+",
+		"Google YouTube API Key": "AIza[0-9A-Za-z\\-_]{35}",
+		"Google YouTube OAuth": "[0-9]+-[0-9A-Za-z_]{32}\\.apps\\.googleusercontent\\.com",
+		"Heroku API Key": "[hH][eE][rR][oO][kK][uU].*[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}",
+		"MailChimp API Key": "[0-9a-f]{32}-us[0-9]{1,2}",
+		"Mailgun API Key": "key-[0-9a-zA-Z]{32}",
+		"URL": "[a-zA-Z]{3,10}://.+",
+		"PayPal Braintree Access Token": "access_token\\$production\\$[0-9a-z]{16}\\$[0-9a-f]{32}",
+		"Picatic API Key": "sk_live_[0-9a-z]{32}",
+		"Slack Webhook": "https://hooks\\.slack\\.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}",
+		"Stripe API Key": "sk_live_[0-9a-zA-Z]{24}",
+		"Stripe Restricted API Key": "rk_live_[0-9a-zA-Z]{24}",
+		"Square Access Token": "sq0atp-[0-9A-Za-z\\-_]{22}",
+		"Square OAuth Secret": "sq0csp-[0-9A-Za-z\\-_]{43}",
+		"Telegram Bot API Key": "[0-9]+:AA[0-9A-Za-z\\-_]{33}",
+		"Twilio API Key": "SK[0-9a-fA-F]{32}",
+		"Twitter Access Token": "[tT][wW][iI][tT][tT][eE][rR].*[1-9][0-9]+-[0-9a-zA-Z]{40}",
+		"Twitter OAuth": "[tT][wW][iI][tT][tT][eE][rR].*['|\"][0-9a-zA-Z]{35,44}['|\"]"
+	}`
+
+	truffehogRegexes := map[string]string{}
+	if err := json.Unmarshal([]byte(truffehogRegexesJson), &truffehogRegexes); err != nil {
+		return nil
+	}
+	return truffehogRegexes
+}
+
+func ejsonAnalysePaths(b *backend) []*framework.Path {
+	return []*framework.Path{
+		&framework.Path{
+			Pattern: "analyse",
+			Fields: map[string]*framework.FieldSchema{
+				"document": &framework.FieldSchema{
+					Type:        framework.TypeString,
+					Description: "ejson document",
+				},
+			},
+			Callbacks: map[logical.Operation]framework.OperationFunc{
+				logical.CreateOperation: b.analyse,
+				logical.UpdateOperation: b.analyse,
+			},
+		},
+	}
+}
+
+func (b *backend) analyse(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	inputData, ok := data.GetOk("document")
+	if !ok {
+		if len(data.Raw) == 0 {
+			return logical.ErrorResponse("no data provided"), logical.ErrInvalidRequest
+		}
+		inputData = data.Raw
+	}
+
+	encData, err := MarshalInput(inputData)
+	if err != nil {
+		return nil, errwrap.Wrapf("failed to marshall json: {{err}}", err)
+	}
+
+	decData, err := DecryptEjson(ctx, encData, req.Storage)
+	if err != nil {
+		return nil, errwrap.Wrapf("failed to decrypt ejson: {{err}}", err)
+	}
+
+	walker := ej.Walker{
+		Action: analyser(identityFunction(b.IdentitySaltOrDefault(ctx, req))),
+	}
+
+	analysedData, err := walker.Walk(decData)
+	if err != nil {
+		return nil, errwrap.Wrapf("failed to analyse ejson: {{err}}", err)
+	}
+	analysedJson := map[string]interface{}{}
+	if err := json.Unmarshal(analysedData, &analysedJson); err != nil {
+		return nil, err
+	}
+
+	return &logical.Response{
+		Data: analysedJson,
+	}, nil
+}
+
+func identityFunction(salt []byte) func([]byte) ([]byte, error) {
+	return func(value []byte) ([]byte, error) {
+		return HashPlaintext(value, salt)
+	}
+}
+
+func analyser(identityFunction func([]byte) ([]byte, error)) func(value []byte) ([]byte, error) {
+	return func(value []byte) ([]byte, error) {
+		identity, err := identityFunction(value)
+		if err != nil {
+			return nil, err
+		}
+
+		result := fmt.Sprintf(
+			"EJA[1:%x:%s:%s]",
+			identity,
+			secretType(value),
+			strings.Join(secretWarnings(value), ","),
+		)
+		return []byte(result), nil
+	}
+}
+
+func secretWarnings(secret []byte) []string {
+	res := []string{}
+	if len(secret) <= 10 {
+		res = append(res, "VERY_SHORT")
+	}
+	if len(secret) > 10 && len(secret) <= 16 {
+		res = append(res, "SHORT")
+	}
+	return res
+}
+
+func secretType(secret []byte) string {
+	for secretType, secretRegexp := range typeRegexes() {
+		if matched, _ := regexp.MatchString(secretRegexp, string(secret)); matched {
+			return secretType
+		}
+	}
+	return "GENERIC_PASSWORD"
+}

--- a/path_ejson_analyse_test.go
+++ b/path_ejson_analyse_test.go
@@ -1,0 +1,47 @@
+package secretsejson
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func TestEJSON_Analyse(t *testing.T) {
+	b, storage := getTestBackend(t)
+
+	EJSON_Keys_Setup(t, b, storage)
+
+	testDocumentJson := `{
+		"_public_key": "15838c2f3260185ad2a8e1298bd507479ff2470b9e9c1fd89e0fdfefe2959f56",
+		"asecret": "EJ[1:6+JkAgsjuL9q21HPH3RKpDcIUEfeDY+P+djp2iRfC2w=:Bu1EWAJUwWJfcc5S63oG4HaxJBc4AO6G:xU8uMuvX4CPBOI7aIdpw/+dB2A64doM6vN6Y]",
+		"_bsecret": "orly",
+		"anumber": 1,
+		"production_signing_key": "EJ[1:6+JkAgsjuL9q21HPH3RKpDcIUEfeDY+P+djp2iRfC2w=:Dpqlq3+j7/Y80aFhOFN9MZeCu635EIrZ:LvLdA8VY+EePsdjoB7VUNe7jNIVJvz1/xuqH8z73MXEYzjCJTru6u08law01CBfTj+tJ3D0nr3Eo5qO5YlyNiTekgfWPFKztQakLHtoWR7qQicXS2us70nP4jij7dlV/K33B+f/rQs8OkeU2]",
+		"github": "EJ[1:6+JkAgsjuL9q21HPH3RKpDcIUEfeDY+P+djp2iRfC2w=:+mx+EZTrHdnLxCVWEtvjqCfYn6JXe908:h48el99MUn7ukFWIeFruk2jHRMHCN1xZXmDGzcgZac+/CggF68krFdyBhL9NMJbm3OZajeBxqI4=]",
+		"backend_system": "EJ[1:6+JkAgsjuL9q21HPH3RKpDcIUEfeDY+P+djp2iRfC2w=:eopckJmGcZRUbCyuZ/kBLGdyf/1qap3x:SVU/DcH2eSS0//pQIerjw8R+XtySZXtSjlV1QB0aVpbMzb65H8obSB3tTVvHVsBSp02NmPjUQn9jgAaKAkZu60ArLoAkmYY=]",
+		"database": {
+			"_username": "admin",
+			"password": "EJ[1:6+JkAgsjuL9q21HPH3RKpDcIUEfeDY+P+djp2iRfC2w=:1LlOBYFfDBDlm1GgyN+kIcKgOUfCB24c:qWqQhU4pOnSVJRo4hxaqAINVoRC88A==]"
+		}
+	}`
+
+	dataInput := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(testDocumentJson), &dataInput); err != nil {
+		t.Fatalf("Could not load test data")
+	}
+
+	req := &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "analysis",
+		Storage:   storage,
+		Data:      dataInput,
+	}
+
+	resp, err := b.HandleRequest(context.Background(), req)
+	if err != nil || (resp != nil && resp.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, resp)
+	}
+
+}


### PR DESCRIPTION
### Example
```bash
$ vault write ejson/keys/3f809a054114cb2565b465628c012999a46db9500ef11c53c677d72f87fc423a private=$(cat /opt/ejson/keys/3f809a054114cb2565b465628c012999a46db9500ef11c53c677d72f87fc423a)
$ vault write -format=json ejson/analyse @/tmp/test.ejson | jq .data
{
  "_bsecret": "orly",
  "_public_key": "3f809a054114cb2565b465628c012999a46db9500ef11c53c677d72f87fc423a",
  "anumber": 1,
  "asecret": "EJA[1:4ec2c261f1112a889f8e55ccc04b07611c4ed9167f2bb644daa00d23d11acd8a:GENERIC_PASSWORD:SHORT]",
  "backend_system": "EJA[1:a884684b8175e05a35eecbf1640df68b6a6b5b08bd99ad8be8732d529045942a:URL:]",
  "database": {
    "_username": "admin",
    "password": "EJA[1:269dad2822a5fd2d0ae5424465573a47f7994b9a1194224645b27d9f8343ab09:GENERIC_PASSWORD:VERY_SHORT]"
  },
  "github": "EJA[1:d997608af40aa72ab9b77ba22dc498591252816c43fc9c06632e663ec80ecb71:GitHub PAT:]",
  "production_signing_key": "EJA[1:c80d182ed348a35600003e5614b315a388c1b4bb4c076221280e1642d07b13c1:PGP private key block:]"
}
```

### Format
```
EJA[V:I:T:W]

EJA[ - header EJson Analysis
V - version
I  - identity string
T - guessed type
W - comma separated list of warnings
]
```

Unfortunately we are not able to inject complex data structures in place of the secret strings, at least not without implementing our own json document walker. Tried with a json marshalled map, but that got escaped into a string regardless. Decided to follow ejson and use a similar string format.
