### PR TITLE
Copy Ejson as a service

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -36,6 +36,7 @@ func Backend() *backend {
 		Help: "",
 		Paths: framework.PathAppend(
 			ejsonRotatePaths(&b),
+			ejsonCopyPaths(&b),
 			ejsonAnalysePaths(&b),
 			ejsonIdentityPath(&b),
 			ejsonDecryptPaths(&b),

--- a/path_ejson_copy.go
+++ b/path_ejson_copy.go
@@ -1,0 +1,78 @@
+package secretsejson
+
+import (
+	"context"
+	"fmt"
+
+	ej "github.com/Shopify/ejson/json"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func ejsonCopyPaths(b *backend) []*framework.Path {
+	return []*framework.Path{
+		{
+			Pattern: "copy",
+			Fields: map[string]*framework.FieldSchema{
+				"document": {
+					Type:        framework.TypeString,
+					Description: "EJSON Document",
+				},
+				"public_key": {
+					Type:        framework.TypeString,
+					Description: "EJSON Public Key",
+				},
+			},
+			Callbacks: map[logical.Operation]framework.OperationFunc{
+				logical.UpdateOperation: b.copy,
+			},
+		},
+	}
+}
+
+func (b *backend) copy(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	documentData, ok := data.GetOk("document")
+	if !ok {
+		return logical.ErrorResponse("no document data provided"), logical.ErrInvalidRequest
+	}
+
+	encData, err := MarshalInput(documentData)
+	if err != nil {
+		return nil, errwrap.Wrapf("failed to marshal json: {{err}}", err)
+	}
+
+	decDoc, err := DecryptEjsonDocument(ctx, req, encData)
+	if err != nil {
+		return nil, err
+	}
+
+	publicKeyData, ok := data.GetOk("public_key")
+	if !ok {
+		return logical.ErrorResponse("no public key data provided"), logical.ErrInvalidRequest
+	}
+
+	path := fmt.Sprintf("keys/%s", publicKeyData)
+	b.Logger().Info(fmt.Sprintf("Encrypting with key pair at %s", path))
+
+	keyPair, err := req.Storage.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find keypair at path %s: %s", path, err)
+	}
+	if keyPair == nil {
+		return nil, fmt.Errorf("failed to find keypair in %s", path)
+	}
+
+	decDoc[ej.PublicKeyField] = publicKeyData
+
+	encDoc, err := EncryptEjsonDocument(ctx, decDoc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt ejson")
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"document": encDoc,
+		},
+	}, nil
+}

--- a/path_ejson_copy_test.go
+++ b/path_ejson_copy_test.go
@@ -1,0 +1,55 @@
+package secretsejson
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	ej "github.com/Shopify/ejson/json"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func TestEJSON_Keys_Copy(t *testing.T) {
+	b, storage := getTestBackend(t)
+	EJSON_Keys_Setup(t, b, storage)
+
+	ejsonDoc := map[string]interface{}{
+		ej.PublicKeyField: "15838c2f3260185ad2a8e1298bd507479ff2470b9e9c1fd89e0fdfefe2959f56",
+		"asecret":         "EJ[1:sdseJpJ3BpP9PO5Qs8IB4urmmYil46edSTek8SjgVGA=:zl7mkBzL4g2d0PE3hPucmfbDjf3aDK7K:iryi3H7wRGWvUI8kjfWLtP3sFiw=]",
+		"_bsecret":        "intentionally_left_unencrypted",
+		"anumber":         1,
+	}
+	ejsonDocBytes, err := json.Marshal(ejsonDoc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	publicKey := "65f9592efefdf0e98df1c9e9b0742ff974705db8921e8a2da5810623f2c83851"
+
+	dataInput := map[string]interface{}{
+		"document":   string(ejsonDocBytes),
+		"public_key": publicKey,
+	}
+
+	reqCopy := &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      "copy",
+		Storage:   storage,
+		Data:      dataInput,
+	}
+
+	respRead, err := b.HandleRequest(context.Background(), reqCopy)
+	if err != nil || (respRead != nil && respRead.IsError()) {
+		t.Fatalf("err:%s resp:%#v\n", err, respRead)
+	}
+
+	copiedDoc, ok := respRead.Data["document"].(map[string]interface{})
+	if !ok {
+		t.Fatal("document missing from response", respRead)
+	}
+
+	if !reflect.DeepEqual(copiedDoc[ej.PublicKeyField], publicKey) {
+		t.Fatalf("public key does not match provided public key:\n Got:      %#v\n Expected: %#v\n", copiedDoc[ej.PublicKeyField], publicKey)
+	}
+}

--- a/path_ejson_keys_test.go
+++ b/path_ejson_keys_test.go
@@ -2,6 +2,7 @@ package secretsejson
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -9,21 +10,29 @@ import (
 )
 
 func EJSON_Keys_Setup(t *testing.T, b logical.Backend, storage logical.Storage) {
-	dataInput := map[string]interface{}{
-		"public":  "15838c2f3260185ad2a8e1298bd507479ff2470b9e9c1fd89e0fdfefe2959f56",
-		"private": "37124bcf00c2d9fd87ddd596162d99c004460fd47130f2d653e45f85a0681cf0",
+	dataInputs := []map[string]interface{}{
+		{
+			"public":  "15838c2f3260185ad2a8e1298bd507479ff2470b9e9c1fd89e0fdfefe2959f56",
+			"private": "37124bcf00c2d9fd87ddd596162d99c004460fd47130f2d653e45f85a0681cf0",
+		},
+		{
+			"public":  "65f9592efefdf0e98df1c9e9b0742ff974705db8921e8a2da5810623f2c83851",
+			"private": "0fc1860a58f54e356d2f03174df064400c99d261695ddd78df9d2c00fcb42173",
+		},
 	}
 
-	reqKP := &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "keys/15838c2f3260185ad2a8e1298bd507479ff2470b9e9c1fd89e0fdfefe2959f56",
-		Storage:   storage,
-		Data:      dataInput,
-	}
+	for _, dataInput := range dataInputs {
+		reqKP := &logical.Request{
+			Operation: logical.CreateOperation,
+			Path:      fmt.Sprintf("keys/%s", dataInput["public"]),
+			Storage:   storage,
+			Data:      dataInput,
+		}
 
-	respKP, err := b.HandleRequest(context.Background(), reqKP)
-	if err != nil || (respKP != nil && respKP.IsError()) {
-		t.Fatalf("err:%s resp:%#v\n", err, respKP)
+		respKP, err := b.HandleRequest(context.Background(), reqKP)
+		if err != nil || (respKP != nil && respKP.IsError()) {
+			t.Fatalf("err:%s resp:%#v\n", err, respKP)
+		}
 	}
 }
 
@@ -88,6 +97,7 @@ func TestEJSON_Keys_Data_List(t *testing.T) {
 
 	dataList := []string{
 		"15838c2f3260185ad2a8e1298bd507479ff2470b9e9c1fd89e0fdfefe2959f56",
+		"65f9592efefdf0e98df1c9e9b0742ff974705db8921e8a2da5810623f2c83851",
 	}
 
 	if !reflect.DeepEqual(respList, dataList) {

--- a/path_ejson_rotate_test.go
+++ b/path_ejson_rotate_test.go
@@ -13,6 +13,11 @@ import (
 func TestEJSON_Keys_Rotate_InlineDoc(t *testing.T) {
 	b, storage := getTestBackend(t)
 	EJSON_Keys_Setup(t, b, storage)
+	publicKeys, err := storage.List(context.Background(), "keys/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inititialKeyCount := len(publicKeys)
 
 	publicKey := "15838c2f3260185ad2a8e1298bd507479ff2470b9e9c1fd89e0fdfefe2959f56"
 	dataInput := map[string]interface{}{
@@ -43,12 +48,12 @@ func TestEJSON_Keys_Rotate_InlineDoc(t *testing.T) {
 		t.Fatalf("public keys did not change: \nPublicKey: %#v\n", rotatedDoc[ej.PublicKeyField])
 	}
 
-	publicKeys, err := storage.List(context.Background(), "keys/")
+	publicKeys, err = storage.List(context.Background(), "keys/")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(publicKeys) != 2 {
+	if inititialKeyCount >= len(publicKeys) {
 		t.Fatalf("keypairs for the rotated document missing from storage")
 	}
 }
@@ -56,6 +61,11 @@ func TestEJSON_Keys_Rotate_InlineDoc(t *testing.T) {
 func TestEJSON_Keys_Rotate_ExplicitDoc(t *testing.T) {
 	b, storage := getTestBackend(t)
 	EJSON_Keys_Setup(t, b, storage)
+	publicKeys, err := storage.List(context.Background(), "keys/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inititialKeyCount := len(publicKeys)
 
 	publicKey := "15838c2f3260185ad2a8e1298bd507479ff2470b9e9c1fd89e0fdfefe2959f56"
 	ejsonDoc := map[string]interface{}{
@@ -95,12 +105,12 @@ func TestEJSON_Keys_Rotate_ExplicitDoc(t *testing.T) {
 		t.Fatalf("public keys did not change: \nPublicKey: %#v\n", rotatedDoc[ej.PublicKeyField])
 	}
 
-	publicKeys, err := storage.List(context.Background(), "keys/")
+	publicKeys, err = storage.List(context.Background(), "keys/")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(publicKeys) != 2 {
+	if inititialKeyCount >= len(publicKeys) {
 		t.Fatalf("keypairs for the rotated document missing from storage")
 	}
 }


### PR DESCRIPTION
Adds a `copy` endpoint which:

1. Decrypts EJSON document
2. Gets the keypair for the provide public key so it can encrypt the EJSON document
3. Encrypts the EJSON document with the specified keypair
4. Returns the re-encrypted EJSON document