### PR TITLE
Add callback to copy for create

### DIFF
--- a/path_ejson_copy.go
+++ b/path_ejson_copy.go
@@ -25,6 +25,7 @@ func ejsonCopyPaths(b *backend) []*framework.Path {
 				},
 			},
 			Callbacks: map[logical.Operation]framework.OperationFunc{
+				logical.CreateOperation: b.copy,
 				logical.UpdateOperation: b.copy,
 			},
 		},


### PR DESCRIPTION
After reading https://www.vaultproject.io/docs/concepts/policies#capabilities where it mentions `create` and `update` are required by most operations, I think this is needed since before I was assuming only `update` would be needed.